### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/sandhose/opentelemetry-prometheus-text-exporter/compare/v0.1.0...v0.2.0) - 2025-08-16
+
+### Other
+
+- Removing a few public items and document all public items

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-prometheus-text-exporter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-prometheus-text-exporter"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["Quentin Gliech <quentingliech@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `opentelemetry-prometheus-text-exporter`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `opentelemetry-prometheus-text-exporter` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_missing.ron

Failed in:
  struct opentelemetry_prometheus_text_exporter::PrometheusSerializer, previously in file /tmp/.tmpNGANwZ/opentelemetry-prometheus-text-exporter/src/serialize.rs:40
  struct opentelemetry_prometheus_text_exporter::ExporterConfig, previously in file /tmp/.tmpNGANwZ/opentelemetry-prometheus-text-exporter/src/exporter.rs:12
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/sandhose/opentelemetry-prometheus-text-exporter/compare/v0.1.0...v0.2.0) - 2025-08-16

### Other

- Removing a few public items and document all public items
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).