### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/sandhose/opentelemetry-prometheus-text-exporter/compare/v0.2.0...v0.2.1) - 2025-09-29
+
+### Other
+
+- Update otel-prometheus fork for benchmarking to 0.31.0
+- Fix the future version in the README
+- Update versions in README
+- Upgrade to opentelemetry 0.31.0
+- apply suggestions from clippy
+- setup tests in CI
+- setup benchmark using CodSpeed
+- remove test for removed code
+
 ## [0.2.0](https://github.com/sandhose/opentelemetry-prometheus-text-exporter/compare/v0.1.0...v0.2.0) - 2025-08-16
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,37 +486,23 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opentelemetry"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.14",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
 dependencies = [
  "js-sys",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-prometheus"
 version = "0.29.1"
-source = "git+https://github.com/sandhose/opentelemetry-rust.git?branch=otel-prometheus-0.30#a60122ce4d534631b70222d84a19bfcb8e9d69a2"
+source = "git+https://github.com/sandhose/opentelemetry-rust.git?branch=otel-prometheus-0.31#8658f59c19df3c9e1f7cea3d77206c1017f01997"
 dependencies = [
  "once_cell",
- "opentelemetry 0.30.0",
- "opentelemetry_sdk 0.30.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prometheus",
- "tracing",
 ]
 
 [[package]]
@@ -525,24 +511,11 @@ version = "0.2.0"
 dependencies = [
  "codspeed-criterion-compat",
  "insta",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-prometheus",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk",
  "prometheus",
  "smartstring",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
-dependencies = [
- "futures-channel",
- "futures-executor",
- "futures-util",
- "opentelemetry 0.30.0",
- "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -554,7 +527,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "thiserror 2.0.14",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-prometheus-text-exporter"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "codspeed-criterion-compat",
  "insta",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,13 +499,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "js-sys",
+]
+
+[[package]]
 name = "opentelemetry-prometheus"
 version = "0.29.1"
 source = "git+https://github.com/sandhose/opentelemetry-rust.git?branch=otel-prometheus-0.30#a60122ce4d534631b70222d84a19bfcb8e9d69a2"
 dependencies = [
  "once_cell",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.30.0",
+ "opentelemetry_sdk 0.30.0",
  "prometheus",
  "tracing",
 ]
@@ -516,9 +525,9 @@ version = "0.2.0"
 dependencies = [
  "codspeed-criterion-compat",
  "insta",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "opentelemetry-prometheus",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.31.0",
  "prometheus",
  "smartstring",
 ]
@@ -532,7 +541,20 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.30.0",
+ "thiserror 2.0.14",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.31.0",
  "thiserror 2.0.14",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-prometheus-text-exporter"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Quentin Gliech <quentingliech@gmail.com>"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ categories = ["development-tools::debugging", "development-tools::profiling"]
 [dependencies]
 
 [dependencies.opentelemetry]
-version = "0.30.0"
+version = "0.31.0"
 default-features = false
 features = ["metrics"]
 
 [dependencies.opentelemetry_sdk]
-version = "0.30.0"
+version = "0.31.0"
 default-features = false
 features = ["metrics", "experimental_metrics_custom_reader"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ prometheus = "0.14"
 [dev-dependencies.opentelemetry-prometheus]
 # https://github.com/open-telemetry/opentelemetry-rust/pull/3076
 git = "https://github.com/sandhose/opentelemetry-rust.git"
-branch = "otel-prometheus-0.30"
+branch = "otel-prometheus-0.31"
 
 [[test]]
 name = "it"

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-opentelemetry-prometheus-text-exporter = "0.1.0"
-opentelemetry = "0.30"
-opentelemetry_sdk = "0.30"
+opentelemetry-prometheus-text-exporter = "0.3.0"
+opentelemetry = "0.31"
+opentelemetry_sdk = "0.31"
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-opentelemetry-prometheus-text-exporter = "0.3.0"
+opentelemetry-prometheus-text-exporter = "0.2.1"
 opentelemetry = "0.31"
 opentelemetry_sdk = "0.31"
 ```


### PR DESCRIPTION



## 🤖 New release

* `opentelemetry-prometheus-text-exporter`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/sandhose/opentelemetry-prometheus-text-exporter/compare/v0.2.0...v0.2.1) - 2025-09-29

### Other

- Update otel-prometheus fork for benchmarking to 0.31.0
- Fix the future version in the README
- Update versions in README
- Upgrade to opentelemetry 0.31.0
- apply suggestions from clippy
- setup tests in CI
- setup benchmark using CodSpeed
- remove test for removed code
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).