### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/sandhose/opentelemetry-prometheus-text-exporter/compare/v0.2.0...v0.2.1) - 2025-09-29
+
+### Added
+
+- Upgrade opentelemetry to 0.31.0
+
+### Other
+
+- apply suggestions from clippy
+- setup tests in CI
+- setup benchmark using CodSpeed
+- remove test for removed code
+
 ## [0.2.0](https://github.com/sandhose/opentelemetry-prometheus-text-exporter/compare/v0.1.0...v0.2.0) - 2025-08-16
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-prometheus-text-exporter"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "codspeed-criterion-compat",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-prometheus-text-exporter"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Quentin Gliech <quentingliech@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `opentelemetry-prometheus-text-exporter`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/sandhose/opentelemetry-prometheus-text-exporter/compare/v0.2.0...v0.2.1) - 2025-09-29

### Added

- Upgrade opentelemetry to 0.31.0

### Other

- apply suggestions from clippy
- setup tests in CI
- setup benchmark using CodSpeed
- remove test for removed code
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).