### PR TITLE
feat: support injecting labels from OTel resource into all metric values as labels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ keywords = [
 ]
 categories = ["development-tools::debugging", "development-tools::profiling"]
 
+[features]
+resource_selector = []
+
 [dependencies]
 
 [dependencies.opentelemetry]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ keywords = [
 categories = ["development-tools::debugging", "development-tools::profiling"]
 
 [features]
+default = ["resource_selector"]
 resource_selector = []
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ exporter.export(&mut output).unwrap();
 println!("{}", String::from_utf8(output).unwrap());
 ```
 
+## Crate Features
+
+Currently supported crate features:
+- *resource_selector*: adds `with_resource_selector()` customization, at the cost of
+  1% to 7% performance degradation.
+
 ## Configuration Options
 
 The exporter supports extensive configuration through the builder pattern:
@@ -87,6 +93,7 @@ let exporter = PrometheusExporter::builder()
 | `without_counter_suffixes()` | Disables `_total` suffix on counter metrics | Suffixes enabled |
 | `without_target_info()` | Disables `target_info` metric generation from resource attributes | target_info enabled |
 | `without_scope_info()` | Disables `otel_scope_info` metric with instrumentation scope labels | scope_info enabled |
+| `with_resource_selector()` | Adds some or all resource attributes to each metric as labels | No additional labels |
 
 ## Output Format
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ println!("{}", String::from_utf8(output).unwrap());
 
 Currently supported crate features:
 - *resource_selector*: adds `with_resource_selector()` customization, at the cost of
-  1% to 7% performance degradation.
+  1% to 7% performance degradation. Enabled by default.
 
 ## Configuration Options
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@
     reason = "The configuration struct has many boolean fields, this is intentional"
 )]
 pub(crate) mod exporter;
+pub(crate) mod resource_selector;
 pub(crate) mod serialize;
 
 pub use self::exporter::{ExporterBuilder, PrometheusExporter};
+pub use self::resource_selector::ResourceSelector;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,10 @@
     reason = "The configuration struct has many boolean fields, this is intentional"
 )]
 pub(crate) mod exporter;
+#[cfg(feature = "resource_selector")]
 pub(crate) mod resource_selector;
 pub(crate) mod serialize;
 
 pub use self::exporter::{ExporterBuilder, PrometheusExporter};
+#[cfg(feature = "resource_selector")]
 pub use self::resource_selector::ResourceSelector;

--- a/src/resource_selector.rs
+++ b/src/resource_selector.rs
@@ -1,0 +1,56 @@
+use std::collections::HashSet;
+
+use opentelemetry::Key;
+
+/// `ResourceSelector` is used to select which resource to export with every
+/// metrics.
+///
+/// By default, the exporter will only export resource as `target_info` metrics
+/// but not inline in every metrics. You can disable this behavior by calling
+/// [`without_target_info`](crate::exporter::ExporterBuilder::without_target_info)
+///
+/// You can add resource to every metrics by set `ResourceSelector` to anything
+/// other than `None`.
+///
+/// By default, ResourceSelector is `None`, meaning resource will not be
+/// attributes of every metrics.
+#[derive(Clone, Debug, Default)]
+#[non_exhaustive]
+pub enum ResourceSelector {
+    /// Export all resource attributes with every metrics.
+    All,
+    /// Do not export any resource attributes with every metrics.
+    #[default]
+    None,
+    /// Export only the resource attributes in the allow list with every
+    /// metrics.
+    KeyAllowList(HashSet<Key>),
+}
+
+impl From<HashSet<opentelemetry::Key>> for ResourceSelector {
+    fn from(keys: HashSet<Key>) -> Self {
+        ResourceSelector::KeyAllowList(keys)
+    }
+}
+
+impl From<bool> for ResourceSelector {
+    fn from(value: bool) -> Self {
+        if value {
+            ResourceSelector::All
+        } else {
+            ResourceSelector::None
+        }
+    }
+}
+
+impl ResourceSelector {
+    #[inline]
+    #[must_use]
+    pub(crate) fn matches(&self, key: &Key) -> bool {
+        match self {
+            Self::None => false,
+            Self::All => true,
+            Self::KeyAllowList(list) => list.contains(key),
+        }
+    }
+}

--- a/src/resource_selector.rs
+++ b/src/resource_selector.rs
@@ -27,9 +27,17 @@ pub enum ResourceSelector {
     KeyAllowList(HashSet<Key>),
 }
 
-impl From<HashSet<opentelemetry::Key>> for ResourceSelector {
+impl From<HashSet<Key>> for ResourceSelector {
     fn from(keys: HashSet<Key>) -> Self {
         ResourceSelector::KeyAllowList(keys)
+    }
+}
+
+impl From<Key> for ResourceSelector {
+    fn from(value: Key) -> Self {
+        let mut allow_list = HashSet::new();
+        allow_list.insert(value);
+        ResourceSelector::KeyAllowList(allow_list)
     }
 }
 

--- a/src/resource_selector.rs
+++ b/src/resource_selector.rs
@@ -51,8 +51,18 @@ impl From<bool> for ResourceSelector {
     }
 }
 
+impl<K: Into<Key>> FromIterator<K> for ResourceSelector {
+    fn from_iter<T: IntoIterator<Item = K>>(iter: T) -> Self {
+        let hash_set: HashSet<_> = iter.into_iter().map(Into::into).collect();
+        if hash_set.is_empty() {
+            ResourceSelector::None
+        } else {
+            ResourceSelector::KeyAllowList(hash_set)
+        }
+    }
+}
+
 impl ResourceSelector {
-    #[inline]
     #[must_use]
     pub(crate) fn matches(&self, key: &Key) -> bool {
         match self {

--- a/src/resource_selector.rs
+++ b/src/resource_selector.rs
@@ -33,24 +33,6 @@ impl From<HashSet<Key>> for ResourceSelector {
     }
 }
 
-impl From<Key> for ResourceSelector {
-    fn from(value: Key) -> Self {
-        let mut allow_list = HashSet::new();
-        allow_list.insert(value);
-        ResourceSelector::KeyAllowList(allow_list)
-    }
-}
-
-impl From<bool> for ResourceSelector {
-    fn from(value: bool) -> Self {
-        if value {
-            ResourceSelector::All
-        } else {
-            ResourceSelector::None
-        }
-    }
-}
-
 impl<K: Into<Key>> FromIterator<K> for ResourceSelector {
     fn from_iter<T: IntoIterator<Item = K>>(iter: T) -> Self {
         let hash_set: HashSet<_> = iter.into_iter().map(Into::into).collect();

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -34,6 +34,17 @@ use opentelemetry_sdk::metrics::data::{
 use smartstring::SmartString;
 
 use crate::exporter::ExporterConfig;
+use crate::resource_selector::ResourceSelector;
+
+/// Internal serialization context
+///
+/// This object exists only during serialization.
+struct SerializerContext<'w, W: Write> {
+    /// Writer that was passed to the serializer
+    writer: &'w mut W,
+    /// Preformatted static labels to append to every metric
+    static_labels: Option<SmartString<smartstring::LazyCompact>>,
+}
 
 /// Prometheus format serializer with configurable options
 #[derive(Debug, Clone)]
@@ -57,21 +68,52 @@ impl PrometheusSerializer {
 
     /// Serialize ResourceMetrics to Prometheus format
     pub fn serialize<W: Write>(&self, rm: &ResourceMetrics, writer: &mut W) -> std::io::Result<()> {
-        self.serialize_resource_metrics(rm, writer)
+        let mut context = SerializerContext {
+            writer,
+            static_labels: self.generate_static_labels(rm.resource())?,
+        };
+        self.serialize_resource_metrics(rm, &mut context)
+    }
+
+    fn generate_static_labels(
+        &self,
+        resource: &Resource,
+    ) -> std::io::Result<Option<SmartString<smartstring::LazyCompact>>> {
+        let mut has_attrs = false;
+        let mut buf = SmartString::<smartstring::LazyCompact>::new();
+        if !matches!(self.config.resource_selector, ResourceSelector::None) {
+            for (key, value) in resource
+                .iter()
+                .filter(|attr| self.config.resource_selector.matches(&attr.0))
+            {
+                let sanitized_key = sanitize_name(key.as_str());
+                // We need a string representation beforehand, as we rely on debug formatter
+                // to properly escape special or non-printable characters.
+                let string_value = value.as_str();
+                if !has_attrs {
+                    has_attrs = true;
+                    write!(&mut buf, "{sanitized_key}={string_value:?}")
+                } else {
+                    write!(&mut buf, ",{sanitized_key}={string_value:?}")
+                }
+                .map_err(std::io::Error::other)?;
+            }
+        }
+        if has_attrs { Ok(Some(buf)) } else { Ok(None) }
     }
 
     fn serialize_resource_metrics<W: Write>(
         &self,
         rm: &ResourceMetrics,
-        writer: &mut W,
+        context: &mut SerializerContext<W>,
     ) -> std::io::Result<()> {
         // Serialize all scope metrics first
         for sm in rm.scope_metrics() {
-            self.serialize_scope_metrics(sm, writer)?;
+            self.serialize_scope_metrics(sm, context)?;
         }
 
         // Serialize resource as target_info
-        self.serialize_resource(rm.resource(), writer)?;
+        self.serialize_resource(rm.resource(), context)?;
 
         Ok(())
     }
@@ -79,20 +121,24 @@ impl PrometheusSerializer {
     fn serialize_resource<W: Write>(
         &self,
         resource: &Resource,
-        writer: &mut W,
+        context: &mut SerializerContext<W>,
     ) -> std::io::Result<()> {
         // Don't serialize empty resources or if target_info is disabled
         if resource.is_empty() || self.config.disable_target_info {
             return Ok(());
         }
 
-        write_type_comment(writer, "target_info", "gauge")?;
-        write_help_comment(writer, "target_info", "Target metadata")?;
+        write_type_comment(context.writer, "target_info", "gauge")?;
+        write_help_comment(context.writer, "target_info", "Target metadata")?;
 
-        write!(writer, "target_info")?;
+        write!(context.writer, "target_info")?;
 
-        let mut label_writer = LabelWriter::new(writer);
+        let mut label_writer = LabelWriter::new(context);
         for (key, value) in resource.iter() {
+            // Skip attributes that were added to `static_labels`
+            if self.config.resource_selector.matches(key) {
+                continue;
+            }
             let sanitized_key = sanitize_name(key.as_str());
             let mut value_buf = SmartString::<smartstring::LazyCompact>::new();
             write!(&mut value_buf, "{value}").map_err(std::io::Error::other)?;
@@ -100,7 +146,7 @@ impl PrometheusSerializer {
         }
         label_writer.finish()?;
 
-        writeln!(writer, " 1")?;
+        writeln!(context.writer, " 1")?;
 
         Ok(())
     }
@@ -108,10 +154,10 @@ impl PrometheusSerializer {
     fn serialize_scope_metrics<W: Write>(
         &self,
         scope_metrics: &opentelemetry_sdk::metrics::data::ScopeMetrics,
-        writer: &mut W,
+        context: &mut SerializerContext<W>,
     ) -> std::io::Result<()> {
         for metric in scope_metrics.metrics() {
-            self.serialize_metric(metric, scope_metrics, writer)?;
+            self.serialize_metric(metric, scope_metrics, context)?;
         }
         Ok(())
     }
@@ -120,7 +166,7 @@ impl PrometheusSerializer {
         &self,
         metric: &Metric,
         scope_metrics: &opentelemetry_sdk::metrics::data::ScopeMetrics,
-        writer: &mut W,
+        context: &mut SerializerContext<W>,
     ) -> std::io::Result<()> {
         let data = metric.data();
 
@@ -157,39 +203,39 @@ impl PrometheusSerializer {
         };
 
         // Write metadata
-        write_type_comment(writer, final_name.as_ref(), prometheus_type)?;
-        write_help_comment(writer, final_name.as_ref(), metric.description())?;
-        write_unit_comment(writer, final_name.as_ref(), converted_unit.as_ref())?;
+        write_type_comment(context.writer, final_name.as_ref(), prometheus_type)?;
+        write_help_comment(context.writer, final_name.as_ref(), metric.description())?;
+        write_unit_comment(context.writer, final_name.as_ref(), converted_unit.as_ref())?;
 
         match data {
             AggregatedMetrics::F64(MetricData::Gauge(gauge)) => {
-                self.serialize_gauge(final_name.as_ref(), gauge, scope_metrics, writer)?;
+                self.serialize_gauge(final_name.as_ref(), gauge, scope_metrics, context)?;
             }
             AggregatedMetrics::U64(MetricData::Gauge(gauge)) => {
-                self.serialize_gauge(final_name.as_ref(), gauge, scope_metrics, writer)?;
+                self.serialize_gauge(final_name.as_ref(), gauge, scope_metrics, context)?;
             }
             AggregatedMetrics::I64(MetricData::Gauge(gauge)) => {
-                self.serialize_gauge(final_name.as_ref(), gauge, scope_metrics, writer)?;
+                self.serialize_gauge(final_name.as_ref(), gauge, scope_metrics, context)?;
             }
 
             AggregatedMetrics::F64(MetricData::Sum(sum)) => {
-                self.serialize_sum(final_name.as_ref(), sum, scope_metrics, writer)?;
+                self.serialize_sum(final_name.as_ref(), sum, scope_metrics, context)?;
             }
             AggregatedMetrics::U64(MetricData::Sum(sum)) => {
-                self.serialize_sum(final_name.as_ref(), sum, scope_metrics, writer)?;
+                self.serialize_sum(final_name.as_ref(), sum, scope_metrics, context)?;
             }
             AggregatedMetrics::I64(MetricData::Sum(sum)) => {
-                self.serialize_sum(final_name.as_ref(), sum, scope_metrics, writer)?;
+                self.serialize_sum(final_name.as_ref(), sum, scope_metrics, context)?;
             }
 
             AggregatedMetrics::F64(MetricData::Histogram(histogram)) => {
-                self.serialize_histogram(final_name.as_ref(), histogram, scope_metrics, writer)?;
+                self.serialize_histogram(final_name.as_ref(), histogram, scope_metrics, context)?;
             }
             AggregatedMetrics::U64(MetricData::Histogram(histogram)) => {
-                self.serialize_histogram(final_name.as_ref(), histogram, scope_metrics, writer)?;
+                self.serialize_histogram(final_name.as_ref(), histogram, scope_metrics, context)?;
             }
             AggregatedMetrics::I64(MetricData::Histogram(histogram)) => {
-                self.serialize_histogram(final_name.as_ref(), histogram, scope_metrics, writer)?;
+                self.serialize_histogram(final_name.as_ref(), histogram, scope_metrics, context)?;
             }
 
             // Skip exponential histograms
@@ -198,7 +244,7 @@ impl PrometheusSerializer {
             | AggregatedMetrics::I64(MetricData::ExponentialHistogram(_)) => {}
         }
 
-        writeln!(writer)?;
+        writeln!(context.writer)?;
 
         Ok(())
     }
@@ -250,9 +296,9 @@ impl PrometheusSerializer {
         &self,
         attributes: impl Iterator<Item = &'a KeyValue>,
         scope_metrics: &opentelemetry_sdk::metrics::data::ScopeMetrics,
-        writer: &mut W,
+        context: &mut SerializerContext<W>,
     ) -> std::io::Result<()> {
-        let mut label_writer = LabelWriter::new(writer);
+        let mut label_writer = LabelWriter::new(context);
 
         write_attributes_as_labels(attributes, &mut label_writer)?;
         self.write_scope_labels(scope_metrics, &mut label_writer)?;
@@ -265,9 +311,9 @@ impl PrometheusSerializer {
         attributes: impl Iterator<Item = &'a KeyValue>,
         scope_metrics: &opentelemetry_sdk::metrics::data::ScopeMetrics,
         le_value: &str,
-        writer: &mut W,
+        context: &mut SerializerContext<W>,
     ) -> std::io::Result<()> {
-        let mut label_writer = LabelWriter::new(writer);
+        let mut label_writer = LabelWriter::new(context);
 
         write_attributes_as_labels(attributes, &mut label_writer)?;
         label_writer.emit("le", le_value)?;
@@ -281,14 +327,14 @@ impl PrometheusSerializer {
         name: &str,
         gauge: &Gauge<T>,
         scope_metrics: &opentelemetry_sdk::metrics::data::ScopeMetrics,
-        writer: &mut W,
+        context: &mut SerializerContext<W>,
     ) -> std::io::Result<()> {
         for data_point in gauge.data_points() {
-            write!(writer, "{name}")?;
-            self.write_metric_labels(data_point.attributes(), scope_metrics, writer)?;
-            write!(writer, " ")?;
-            data_point.value().serialize(writer)?;
-            writeln!(writer)?;
+            write!(context.writer, "{name}")?;
+            self.write_metric_labels(data_point.attributes(), scope_metrics, context)?;
+            write!(context.writer, " ")?;
+            data_point.value().serialize(context.writer)?;
+            writeln!(context.writer)?;
         }
 
         Ok(())
@@ -299,14 +345,14 @@ impl PrometheusSerializer {
         name: &str,
         sum: &Sum<T>,
         scope_metrics: &opentelemetry_sdk::metrics::data::ScopeMetrics,
-        writer: &mut W,
+        context: &mut SerializerContext<W>,
     ) -> std::io::Result<()> {
         for data_point in sum.data_points() {
-            write!(writer, "{name}")?;
-            self.write_metric_labels(data_point.attributes(), scope_metrics, writer)?;
-            write!(writer, " ")?;
-            data_point.value().serialize(writer)?;
-            writeln!(writer)?;
+            write!(context.writer, "{name}")?;
+            self.write_metric_labels(data_point.attributes(), scope_metrics, context)?;
+            write!(context.writer, " ")?;
+            data_point.value().serialize(context.writer)?;
+            writeln!(context.writer)?;
         }
 
         Ok(())
@@ -317,46 +363,46 @@ impl PrometheusSerializer {
         name: &str,
         histogram: &Histogram<T>,
         scope_metrics: &opentelemetry_sdk::metrics::data::ScopeMetrics,
-        writer: &mut W,
+        context: &mut SerializerContext<W>,
     ) -> std::io::Result<()> {
         for data_point in histogram.data_points() {
             // _count metric
-            write!(writer, "{name}_count")?;
-            self.write_metric_labels(data_point.attributes(), scope_metrics, writer)?;
-            write!(writer, " ")?;
-            data_point.count().serialize(writer)?;
-            writeln!(writer)?;
+            write!(context.writer, "{name}_count")?;
+            self.write_metric_labels(data_point.attributes(), scope_metrics, context)?;
+            write!(context.writer, " ")?;
+            data_point.count().serialize(context.writer)?;
+            writeln!(context.writer)?;
 
             // _sum metric
-            write!(writer, "{name}_sum")?;
-            self.write_metric_labels(data_point.attributes(), scope_metrics, writer)?;
-            write!(writer, " ")?;
-            data_point.sum().serialize(writer)?;
-            writeln!(writer)?;
+            write!(context.writer, "{name}_sum")?;
+            self.write_metric_labels(data_point.attributes(), scope_metrics, context)?;
+            write!(context.writer, " ")?;
+            data_point.sum().serialize(context.writer)?;
+            writeln!(context.writer)?;
 
             // _bucket metrics
             let mut cumulative_count = 0u64;
             for (bound, count) in data_point.bounds().zip(data_point.bucket_counts()) {
                 cumulative_count += count;
 
-                write!(writer, "{name}_bucket")?;
+                write!(context.writer, "{name}_bucket")?;
                 self.write_bucket_labels(
                     data_point.attributes(),
                     scope_metrics,
                     &bound.to_string(),
-                    writer,
+                    context,
                 )?;
-                write!(writer, " ")?;
-                cumulative_count.serialize(writer)?;
-                writeln!(writer)?;
+                write!(context.writer, " ")?;
+                cumulative_count.serialize(context.writer)?;
+                writeln!(context.writer)?;
             }
 
             // +Inf bucket
-            write!(writer, "{name}_bucket")?;
-            self.write_bucket_labels(data_point.attributes(), scope_metrics, "+Inf", writer)?;
-            write!(writer, " ")?;
-            data_point.count().serialize(writer)?;
-            writeln!(writer)?;
+            write!(context.writer, "{name}_bucket")?;
+            self.write_bucket_labels(data_point.attributes(), scope_metrics, "+Inf", context)?;
+            write!(context.writer, " ")?;
+            data_point.count().serialize(context.writer)?;
+            writeln!(context.writer)?;
         }
 
         Ok(())
@@ -539,15 +585,15 @@ fn add_unit_suffix<'a>(name: &'a str, unit: &str) -> Cow<'a, str> {
 /// Writes attributes as Prometheus labels directly to the writer.
 ///
 /// Handles writing the brackets and separating labels with commas.
-struct LabelWriter<'a, W: Write> {
-    writer: &'a mut W,
+struct LabelWriter<'a, 'w: 'a, W: Write> {
+    context: &'a mut SerializerContext<'w, W>,
     has_written: bool,
 }
 
-impl<'a, W: Write> LabelWriter<'a, W> {
-    fn new(writer: &'a mut W) -> Self {
+impl<'a, 'w: 'a, W: Write> LabelWriter<'a, 'w, W> {
+    fn new(context: &'a mut SerializerContext<'w, W>) -> Self {
         Self {
-            writer,
+            context,
             has_written: false,
         }
     }
@@ -555,18 +601,24 @@ impl<'a, W: Write> LabelWriter<'a, W> {
     fn emit(&mut self, key: &str, value: &str) -> std::io::Result<()> {
         if !self.has_written {
             self.has_written = true;
-            write!(self.writer, "{{")?;
+            write!(self.context.writer, "{{")?;
         } else {
-            write!(self.writer, ",")?;
+            write!(self.context.writer, ",")?;
         }
 
-        write!(self.writer, "{key}={value:?}")?;
+        write!(self.context.writer, "{key}={value:?}")?;
         Ok(())
     }
 
     fn finish(self) -> std::io::Result<()> {
-        if self.has_written {
-            write!(self.writer, "}}")?;
+        if let Some(static_labels) = &self.context.static_labels {
+            if self.has_written {
+                write!(self.context.writer, ",{static_labels}}}")?;
+            } else {
+                write!(self.context.writer, "{{{static_labels}}}")?;
+            }
+        } else if self.has_written {
+            write!(self.context.writer, "}}")?;
         }
         Ok(())
     }


### PR DESCRIPTION
This implements `ExporterBuilder::with_resource_selector()`. This is often handy, and is periodically asked by my users.

I tried rather hard to keep performance degradation to a minimum, so this is gated under a feature flag.

I'll attach bench comparisons below. All were ran on an old Zen1 x86_86 machine, with latest nightly Rust.

Closes #4.