### PR TITLE
chore: bump otel dependencies to 0.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,13 +495,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "js-sys",
+]
+
+[[package]]
 name = "opentelemetry-prometheus"
 version = "0.29.1"
 source = "git+https://github.com/sandhose/opentelemetry-rust.git?branch=otel-prometheus-0.31#8658f59c19df3c9e1f7cea3d77206c1017f01997"
 dependencies = [
  "once_cell",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.31.0",
+ "opentelemetry_sdk 0.31.0",
  "prometheus",
 ]
 
@@ -511,9 +520,9 @@ version = "0.2.1"
 dependencies = [
  "codspeed-criterion-compat",
  "insta",
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "opentelemetry-prometheus",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.32.0",
  "prometheus",
  "smartstring",
 ]
@@ -527,7 +536,21 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.31.0",
+ "thiserror 2.0.14",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.32.0",
+ "portable-atomic",
  "thiserror 2.0.14",
 ]
 
@@ -593,6 +616,12 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ categories = ["development-tools::debugging", "development-tools::profiling"]
 [dependencies]
 
 [dependencies.opentelemetry]
-version = "0.31.0"
+version = "0.32.0"
 default-features = false
 features = ["metrics"]
 
 [dependencies.opentelemetry_sdk]
-version = "0.31.0"
+version = "0.32.0"
 default-features = false
 features = ["metrics", "experimental_metrics_custom_reader"]
 


### PR DESCRIPTION
Hi there. We're using this as a optional dependency to publish Prometheus metrics locally. Currently this crate is not compatible with the opentelemetry 0.32.x crates. I've bumped the relevant versions to make it work. Thanks for the crate :pray: 