### PR TITLE
feat!: update to opentelemetry 0.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,9 +486,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "js-sys",
  "tracing",
@@ -496,13 +496,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-prometheus"
-version = "0.29.1"
-source = "git+https://github.com/sandhose/opentelemetry-rust.git?branch=otel-prometheus-0.31#8658f59c19df3c9e1f7cea3d77206c1017f01997"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0359983e7f79cf33c9abd89e5d7ddf67c46c419d0148598022d70e70c01aba"
 dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry_sdk",
  "prometheus",
+ "tracing",
 ]
 
 [[package]]
@@ -520,14 +522,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
+ "portable-atomic",
  "thiserror 2.0.14",
 ]
 
@@ -593,6 +596,12 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ categories = ["development-tools::debugging", "development-tools::profiling"]
 [dependencies]
 
 [dependencies.opentelemetry]
-version = "0.31.0"
+version = "0.32.0"
 default-features = false
 features = ["metrics"]
 
 [dependencies.opentelemetry_sdk]
-version = "0.31.0"
+version = "0.32.0"
 default-features = false
 features = ["metrics", "experimental_metrics_custom_reader"]
 
@@ -40,9 +40,7 @@ criterion = { package = "codspeed-criterion-compat", version = "3.0.5" }
 prometheus = "0.14"
 
 [dev-dependencies.opentelemetry-prometheus]
-# https://github.com/open-telemetry/opentelemetry-rust/pull/3076
-git = "https://github.com/sandhose/opentelemetry-rust.git"
-branch = "otel-prometheus-0.31"
+version = "0.32.0"
 
 [[test]]
 name = "it"


### PR DESCRIPTION
Bump the opentelemetry and opentelemetry_sdk dependencies to 0.32. The public API now exposes opentelemetry 0.32 types, which is a breaking change for downstreams. No source changes were required.

Also switch the opentelemetry-prometheus dev-dependency from the sandhose opentelemetry-rust fork branch to the now-published 0.32.0 release on crates.io.