### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/sandhose/opentelemetry-prometheus-text-exporter/compare/v0.2.1...v0.3.0) - 2026-06-17
+
+### Added
+
+- [**breaking**] update to opentelemetry 0.32
+
 ## [0.2.1](https://github.com/sandhose/opentelemetry-prometheus-text-exporter/compare/v0.2.0...v0.2.1) - 2025-09-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-prometheus-text-exporter"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "codspeed-criterion-compat",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-prometheus-text-exporter"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 authors = ["Quentin Gliech <quentingliech@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `opentelemetry-prometheus-text-exporter`: 0.2.1 -> 0.3.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/sandhose/opentelemetry-prometheus-text-exporter/compare/v0.2.1...v0.3.0) - 2026-06-17

### Added

- [**breaking**] update to opentelemetry 0.32
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).